### PR TITLE
Unify statistics

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -3,6 +3,7 @@ atl_server_statistics.mod_storage = minetest.get_mod_storage()
 atl_server_statistics.modpath = minetest.get_modpath("atl_server_statistics")
 atl_server_statistics.color_message = ""
 atl_server_statistics.reset_requests = {}
+atl_server_statistics.statistics = {"Messages Count", "Deaths Count", "Kills Count", "Nodes Dug", "Nodes Placed", "Items Crafted", "PlayTime"}
 
 function atl_server_statistics.load_file(path)
     local status, err = pcall(dofile, path)

--- a/script/api.lua
+++ b/script/api.lua
@@ -30,7 +30,7 @@ function atl_server_statistics.log_error(message)
 end
 
 function atl_server_statistics.player_has_stats(player_name)
-    for _, stat in ipairs({"Messages Count", "Deaths Count", "Kills Count", "Nodes Dug", "Nodes Placed", "Items Crafted", "PlayTime"}) do
+    for _, stat in ipairs(atl_server_statistics.statistics) do
         if atl_server_statistics.mod_storage:contains(player_name .. "_" .. stat) then
             return true
         end

--- a/script/commands.lua
+++ b/script/commands.lua
@@ -13,10 +13,9 @@ minetest.register_chatcommand("stats", {
         if atl_server_statistics.is_player_online(target_player_name) then
             atl_server_statistics.update_playtime_on_stats(target_player_name)
         end
-        local stats = {"Messages Count", "Deaths Count", "Kills Count", "Nodes Dug", "Nodes Placed", "Items Crafted", "PlayTime"}
         local stats_message = string.format("-!- Statistic of %s <> ", target_player_name)
         local has_stats = false
-        for _, stat in ipairs(stats) do
+        for _, stat in ipairs(atl_server_statistics.statistics) do
             if atl_server_statistics.mod_storage:contains(target_player_name .. "_" .. stat) then
                 local value = atl_server_statistics.get_stat(target_player_name, stat)
                 if value and value > 0 then

--- a/script/reset.lua
+++ b/script/reset.lua
@@ -1,6 +1,5 @@
 function atl_server_statistics.reset_player_stats(player_name)
-    local stats = {"Messages Count", "Deaths Count", "Kills Count", "Nodes Dug", "Nodes Placed", "Items Crafted", "PlayTime"}
-    for _, stat in ipairs(stats) do
+    for _, stat in ipairs(atl_server_statistics.statistics) do
         atl_server_statistics.mod_storage:set_int(player_name .. "_" .. stat, 0)
     end
     minetest.chat_send_player(player_name, minetest.colorize("#00FF00", "Your statistics have been reset."))


### PR DESCRIPTION
This pull request eliminates the duplicate values of possible statistics and defines them in `init.lua`. This way, it is easier to add new statistic types.